### PR TITLE
fix(api): harden auth — enforce JWT secrets, fix middleware ordering

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -9,3 +9,13 @@
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 DATABASE_URL="postgresql://user:password@localhost:5432/todo?schema=public"
+
+# JWT signing secrets — REQUIRED in production (the app throws on startup if unset).
+# Generate strong random values, e.g. `openssl rand -hex 32`.
+ACCESS_TOKEN_SECRET=""
+REFRESH_TOKEN_SECRET=""
+
+# Optional
+# PORT=3000
+# NODE_ENV=development
+# CORS_ORIGIN="http://localhost:3001"

--- a/api/controllers/__tests__/auth.test.ts
+++ b/api/controllers/__tests__/auth.test.ts
@@ -6,7 +6,6 @@ import * as bcrypt from "bcryptjs";
 import {
   ACCESS_TOKEN_SECRET,
   REFRESH_TOKEN_SECRET,
-  expiresIn,
 } from "../../middlewares/checkJwt";
 
 jest.mock("bcryptjs");

--- a/api/controllers/auth.controller.ts
+++ b/api/controllers/auth.controller.ts
@@ -5,7 +5,6 @@ import * as bcrypt from "bcryptjs";
 import {
   ACCESS_TOKEN_SECRET,
   REFRESH_TOKEN_SECRET,
-  expiresIn,
 } from "../middlewares/checkJwt";
 import { UserService, AuthService } from "./../services";
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -16,13 +16,15 @@ const PORT = process.env.PORT || 3000;
 const app: Express = express();
 
 app.use(morganMiddleware);
-app.use(cors());
+app.use(cors({ origin: process.env.CORS_ORIGIN?.split(",") ?? true }));
 app.use(helmet());
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
 const swaggerDocument = YAML.load("./basic-api-doc.yml");
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+
+app.get("/health", (_, res) => res.send("ok"));
 
 app.get("/logger", (_, res) => {
   Logger.error("This is an error log");
@@ -35,9 +37,9 @@ app.get("/logger", (_, res) => {
 });
 
 app.use("/", AuthRouter);
-app.use("/user", UserRouter, verifyToken);
-app.use("/project", ProjectRouter, verifyToken);
+app.use("/user", verifyToken, UserRouter);
+app.use("/project", verifyToken, ProjectRouter);
 // will use /tasklist always under the project
-app.use("/task", TaskRouter, verifyToken);
+app.use("/task", verifyToken, TaskRouter);
 
 app.listen(PORT, () => console.log(`Running on ${PORT} ⚡`));

--- a/api/middlewares/checkJwt.ts
+++ b/api/middlewares/checkJwt.ts
@@ -2,14 +2,24 @@ import { NextFunction, Router, Response, Request } from "express";
 import * as jwt from "jsonwebtoken";
 
 // TODO: move this to constants
-const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET || "not-a-secret";
-const REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET || "not-a-secret";
-const expiresIn = "1m";
+const isProd = process.env.NODE_ENV === "production";
+
+function requireSecret(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    if (isProd) {
+      throw new Error(`Missing required environment variable: ${name}`);
+    }
+    return "not-a-secret"; // dev/test only fallback
+  }
+  return value;
+}
+
+const ACCESS_TOKEN_SECRET = requireSecret("ACCESS_TOKEN_SECRET");
+const REFRESH_TOKEN_SECRET = requireSecret("REFRESH_TOKEN_SECRET");
 
 async function verifyToken(req: Request, res: Response, next: NextFunction) {
   //Get auth header value
-  console.log("verifyToken1", req.headers.authorization);
-
   const token = req.headers.authorization?.split(" ")[1];
   if (!token) {
     res.status(401).json({ err: "token not found" });
@@ -33,4 +43,4 @@ async function verifyToken(req: Request, res: Response, next: NextFunction) {
   }
 }
 
-export { verifyToken, ACCESS_TOKEN_SECRET, REFRESH_TOKEN_SECRET, expiresIn };
+export { verifyToken, ACCESS_TOKEN_SECRET, REFRESH_TOKEN_SECRET };


### PR DESCRIPTION
Security hardening for the API auth layer. checkJwt now throws on startup in production when ACCESS_TOKEN_SECRET/REFRESH_TOKEN_SECRET are unset (was an insecure 'not-a-secret' fallback), removes a console.log leaking the Authorization header, and drops the unused expiresIn export. index.ts fixes a middleware-ordering bug where verifyToken was registered after the routers (so /user, /project, /task were unprotected), makes CORS configurable via CORS_ORIGIN, and adds a /health endpoint. .env.example documents the now-required secrets. See commit for full details.