### PR TITLE
fix(deploy): install devDependencies during Render build

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,7 +9,9 @@ services:
     rootDir: api
     plan: free
     branch: main
-    buildCommand: npm install && npm run build
+    # --include=dev: NODE_ENV=production (below) makes npm skip devDependencies,
+    # but the TypeScript build needs @types/* and tsc at build time.
+    buildCommand: npm install --include=dev && npm run build
     startCommand: npm start
     healthCheckPath: /health
     autoDeploy: true


### PR DESCRIPTION
## Problem
Render deploy build failed: `TS7016: Could not find a declaration file for module 'jsonwebtoken' / 'bcryptjs' / 'cors'`.

`render.yaml` sets `NODE_ENV=production`, which makes `npm install` **omit devDependencies**. Those `@types/*` live in `devDependencies`, so `tsc` couldn't find them at build time. Reproduced locally with `NODE_ENV=production npm install && npm run build`.

## Fix
Add `--include=dev` to the build command so devDeps (tsc + `@types/*`) are installed at build time. `NODE_ENV=production` stays (the app needs it at runtime for fail-closed auth/CORS). Verified the fix builds clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)