### PR TITLE
feat(ui): add dark mode with persistent theme toggle

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "ui-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["start"],
+      "port": 3000,
+      "autoPort": true,
+      "cwd": "ui"
+    }
+  ]
+}

--- a/ui/src/components/layout/navigation/header-bar/index.tsx
+++ b/ui/src/components/layout/navigation/header-bar/index.tsx
@@ -11,6 +11,9 @@ import AppBar from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
 import IconButton from "@mui/material/IconButton";
 import MenuIcon from "@mui/icons-material/Menu";
+import Brightness4Icon from "@mui/icons-material/Brightness4";
+import Brightness7Icon from "@mui/icons-material/Brightness7";
+import { useColorMode } from "providers/app-provider";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 
@@ -21,6 +24,7 @@ import Container from "@mui/material/Container";
 import Button from "@mui/material/Button";
 
 const NewResponsiveHeader = () => {
+  const { mode, toggleColorMode } = useColorMode();
   const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(
     null
   );
@@ -105,6 +109,13 @@ const NewResponsiveHeader = () => {
           <Box sx={{ flexGrow: 1 }} />
 
           <SearchBar />
+          <IconButton
+            onClick={toggleColorMode}
+            color="inherit"
+            aria-label="toggle dark mode"
+          >
+            {mode === "dark" ? <Brightness7Icon /> : <Brightness4Icon />}
+          </IconButton>
           <UserStatus />
         </Toolbar>
       </Container>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -3,8 +3,7 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
-  background-color: #f4f6f8;
-  color: #20262b;
+  /* background/text colors come from the MUI theme via CssBaseline */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/ui/src/pages/Home/ProjectsView/components/SideBar.tsx
+++ b/ui/src/pages/Home/ProjectsView/components/SideBar.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import React from "react";
-import Theme from "styles/theme";
 
 export const SideBar = (props: any) => (
   <SideBarView>
@@ -16,7 +15,7 @@ export const SideBar = (props: any) => (
 
 const SideBarView = styled.header`
   float: left;
-  border: 2px solid ${Theme.colors.border};
+  border: 2px solid ${({ theme }) => theme.colors.border};
   margin-bottom: 25px;
   padding-right: 10px;
   overflow: hidden;
@@ -26,13 +25,13 @@ const Menu = styled.header`
   text-align: center;
   padding-right: 10px;
   header & div {
-    background-color: ${Theme.colors.pageBg};
+    background-color: ${({ theme }) => theme.colors.pageBg};
     padding: 8px;
     margin-top: 7px;
 
     display: block;
     width: 100%;
-    color: ${Theme.colors.textPrimary};
+    color: ${({ theme }) => theme.colors.textPrimary};
   }
 `;
 

--- a/ui/src/pages/Home/ProjectsView/components/styled.ts
+++ b/ui/src/pages/Home/ProjectsView/components/styled.ts
@@ -1,10 +1,9 @@
 import styled from "@emotion/styled";
-import Theme from "styles/theme";
 
 const ProjectCardContainer = styled.div`
   width: 30vmax;
   border-radius: 4px;
-  border: 2px solid ${Theme.colors.border};
+  border: 2px solid ${({ theme }) => theme.colors.border};
   margin: 1.5rem 0.5rem 1.5rem 0.5rem;
   overflow: hidden;
 `;

--- a/ui/src/pages/Home/TasklistsView/components/styled.ts
+++ b/ui/src/pages/Home/TasklistsView/components/styled.ts
@@ -1,16 +1,15 @@
 import styled from "@emotion/styled";
-import Theme from "styles/theme";
 
 const TasklistCardContainer = styled.div`
   width: 100%;
-  border: 2px solid ${Theme.colors.border};
+  border: 2px solid ${({ theme }) => theme.colors.border};
   border-radius: 4px;
   margin: 1.5rem 0.5rem 1.5rem 0.5rem;
   overflow: hidden;
 `;
 
 const CardTitle = styled.div`
-  background-color: ${Theme.colors.cardHeader};
+  background-color: ${({ theme }) => theme.colors.cardHeader};
   padding: 0.33rem 1rem 0.33rem 1rem;
   border-bottom: 1px solid;
 `;

--- a/ui/src/pages/Home/TasksView/components/SimpleTaskCard/SimpleTaskCard.styled.ts
+++ b/ui/src/pages/Home/TasksView/components/SimpleTaskCard/SimpleTaskCard.styled.ts
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled/macro";
-import Theme from "styles/theme";
 // import styled from "@emotion/styled";
 // import { MyThemeType } from "styles/theme";
 // import { styled, alpha } from "@mui/material/styles";
@@ -7,14 +6,14 @@ import Theme from "styles/theme";
 
 const ProjectCardContainer = styled.div`
   width: 30vmax;
-  border: 2px solid ${Theme.colors.border};
+  border: 2px solid ${({ theme }) => theme.colors.border};
   margin: 1.5rem 0.5rem 1.5rem 0.5rem;
   overflow: hidden;
 `;
 
 const TasklistCardContainer = styled.div`
   width: 30vmax;
-  border: 2px solid ${Theme.colors.border};
+  border: 2px solid ${({ theme }) => theme.colors.border};
   margin: 1.5rem 0.5rem 1.5rem 0.5rem;
   overflow: hidden;
 `;
@@ -40,7 +39,7 @@ const CardTitle = styled.div`
 const CardCreateTitle = styled.div`
   display: flex;
   flex-direction: column;
-  background-color: ${Theme.colors.cardHeader};
+  background-color: ${({ theme }) => theme.colors.cardHeader};
   padding: 0.33rem 0 0.33rem 1rem;
   border-bottom: 1px solid;
 `;

--- a/ui/src/pages/Home/TasksView/components/SimpleTaskCard/index.tsx
+++ b/ui/src/pages/Home/TasksView/components/SimpleTaskCard/index.tsx
@@ -11,7 +11,6 @@ import { Delete, Build, Save } from "@mui/icons-material";
 import { Paper, Card } from "@mui/material";
 
 import Typography from "@mui/material/Typography";
-import Theme from "styles/theme";
 
 // interface TaskProps {
 //   id: number;
@@ -76,8 +75,9 @@ export const SimpleTaskCard = ({
   return (
     <Card
       elevation={3}
-      style={{
-        border: `2px solid ${Theme.colors.border}`,
+      sx={{
+        border: "2px solid",
+        borderColor: "divider",
         borderRadius: "4px",
         margin: "0.5rem 0.2rem",
         overflow: "hidden",

--- a/ui/src/pages/Home/TasksView/tasks.page.tsx
+++ b/ui/src/pages/Home/TasksView/tasks.page.tsx
@@ -6,7 +6,6 @@ import { TaskCard } from "pages/Home/components/TaskCard";
 import { NewTaskCard } from "pages/Home/components/NewTaskCard";
 
 import styled from "@emotion/styled/macro";
-import Theme from "styles/theme";
 import { useParams } from "react-router-dom";
 import { IProjectDetails, ITaskDetails } from "interfaces";
 import { Link as ReactLink } from "react-router-dom";
@@ -227,8 +226,8 @@ const ColumnContainer = styled.div`
   min-width: 400px;
   max-width: 600px;
   margin: 8px;
-  border: 1px solid ${Theme.colors.border};
-  background-color: ${Theme.colors.surface};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  background-color: ${({ theme }) => theme.colors.surface};
   border-radius: 2px;
 `;
 
@@ -236,16 +235,20 @@ interface StyledDivProps {
   isDragging?: boolean;
 }
 const TaskContainer = styled.div<StyledDivProps>`
-  border: 1px solid ${Theme.colors.border};
+  border: 1px solid ${({ theme }) => theme.colors.border};
   padding: 8px;
   margin-bottom: 8px;
 
-  background-color: ${(props) =>
-    props.isDragging ? Theme.colors.grassGreenLight : Theme.colors.surface};
+  background-color: ${({ theme, isDragging }) =>
+    isDragging
+      ? theme.palette.mode === "dark"
+        ? theme.colors.grassGreenDark
+        : theme.colors.grassGreenLight
+      : theme.colors.surface};
 
   &:focus {
     outline: none;
-    border-color: ${Theme.colors.ocean};
+    border-color: ${({ theme }) => theme.colors.ocean};
   }
 `;
 
@@ -277,7 +280,7 @@ const ColumnsRowContainer = styled.div`
 `;
 
 const CardTitle = styled.div`
-  background-color: ${Theme.colors.cardHeader};
+  background-color: ${({ theme }) => theme.colors.cardHeader};
   padding: 0.33rem 0 0.33rem 1rem;
   border-bottom: 1px solid;
 `;

--- a/ui/src/pages/Home/components/GenericCard.tsx
+++ b/ui/src/pages/Home/components/GenericCard.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Link as ReactLink } from "react-router-dom";
 import Link from "@mui/material/Link";
 import styled from "@emotion/styled/macro";
-import Theme from "styles/theme";
 
 interface CardProps {
   id: number;
@@ -42,13 +41,13 @@ export const GenericCard: React.FC<CardProps> = ({
 
 const CardContainer = styled.div`
   width: 30vmax;
-  border: 2px solid ${Theme.colors.border};
+  border: 2px solid ${({ theme }) => theme.colors.border};
   margin: 1.5rem 0.5rem 1.5rem 0.5rem;
   overflow: hidden;
 `;
 
 const CardTitle = styled.div`
-  background-color: ${Theme.colors.cardHeader};
+  background-color: ${({ theme }) => theme.colors.cardHeader};
   padding: 0.33rem 0 0.33rem 1rem;
   border-bottom: 1px solid;
 `;

--- a/ui/src/pages/Home/components/NewTaskCard.tsx
+++ b/ui/src/pages/Home/components/NewTaskCard.tsx
@@ -11,7 +11,6 @@ import { Delete, Build, Save } from "@mui/icons-material";
 import { Paper, Card } from "@mui/material";
 
 import Typography from "@mui/material/Typography";
-import Theme from "styles/theme";
 
 interface TaskProps {
   id: number;
@@ -77,8 +76,9 @@ export const ViewTaskCard = ({
   return (
     <Card
       elevation={3}
-      style={{
-        border: `2px solid ${Theme.colors.border}`,
+      sx={{
+        border: "2px solid",
+        borderColor: "divider",
         borderRadius: "4px",
         margin: "0.5rem 0.2rem",
         overflow: "hidden",

--- a/ui/src/pages/Home/components/TaskCard.tsx
+++ b/ui/src/pages/Home/components/TaskCard.tsx
@@ -11,7 +11,6 @@ import { Delete, Build, Save } from "@mui/icons-material";
 import { Paper, Card } from "@mui/material";
 
 import Typography from "@mui/material/Typography";
-import Theme from "styles/theme";
 
 interface TaskProps {
   id: number;
@@ -77,8 +76,9 @@ export const ViewTaskCard = ({
   return (
     <Card
       elevation={3}
-      style={{
-        border: `2px solid ${Theme.colors.border}`,
+      sx={{
+        border: "2px solid",
+        borderColor: "divider",
         borderRadius: "4px",
         margin: "0.5rem 0.2rem",
         overflow: "hidden",

--- a/ui/src/pages/Home/components/styled.ts
+++ b/ui/src/pages/Home/components/styled.ts
@@ -1,23 +1,22 @@
 import styled from "@emotion/styled/macro";
-import Theme from "styles/theme";
 
 const ProjectCardContainer = styled.div`
   width: 30vmax;
-  border: 2px solid ${Theme.colors.border};
+  border: 2px solid ${({ theme }) => theme.colors.border};
   margin: 1.5rem 0.5rem 1.5rem 0.5rem;
   overflow: hidden;
 `;
 
 const TasklistCardContainer = styled.div`
   width: 30vmax;
-  border: 2px solid ${Theme.colors.border};
+  border: 2px solid ${({ theme }) => theme.colors.border};
   margin: 1.5rem 0.5rem 1.5rem 0.5rem;
   overflow: hidden;
 `;
 
 const TaskContainer = styled.div`
   width: 30vmax;
-  border: 2px solid ${Theme.colors.border};
+  border: 2px solid ${({ theme }) => theme.colors.border};
   border-radius: 4px;
   margin: 0.5rem 0.2rem;
   overflow: hidden;
@@ -31,7 +30,7 @@ const CardTitle = styled.div`
 const CardCreateTitle = styled.div`
   display: flex;
   flex-direction: column;
-  background-color: ${Theme.colors.cardHeader};
+  background-color: ${({ theme }) => theme.colors.cardHeader};
   padding: 0.33rem 0 0.33rem 1rem;
   border-bottom: 1px solid;
 `;

--- a/ui/src/pages/Home/home.style.tsx
+++ b/ui/src/pages/Home/home.style.tsx
@@ -1,15 +1,14 @@
 import styled from "@emotion/styled";
-import Theme from "styles/theme";
 
 export const MainWrapper = styled.main`
-  border: 2px solid ${Theme.colors.border};
+  border: 2px solid ${({ theme }) => theme.colors.border};
   margin-bottom: 25px;
   padding-right: 10px;
   overflow: hidden;
 `;
 
 export const MainContent = styled.main`
-  border: 2px solid ${Theme.colors.border};
+  border: 2px solid ${({ theme }) => theme.colors.border};
   margin-bottom: 25px;
   padding-right: 10px;
   overflow: hidden;

--- a/ui/src/pages/Login/index.tsx
+++ b/ui/src/pages/Login/index.tsx
@@ -7,6 +7,7 @@ import { Logo } from "../../components/logo";
 import { Spinner, FormGroup, CircleButton } from "../../components/lib";
 import { TextField } from "@mui/material";
 import { display } from "@mui/system";
+import { useTheme } from "@mui/material/styles";
 import Button from "@mui/material/Button";
 import { AxiosResponse } from "axios";
 import { IUserSession } from "interfaces/users";
@@ -79,8 +80,17 @@ interface LoginPropsInterface {
 }
 
 export const Login = ({ login, register }: LoginPropsInterface) => {
+  const theme = useTheme();
   const [openModal, setOpenModal] = React.useState("none");
   const [error, setError] = React.useState("");
+
+  // @reach/dialog ships a fixed white background — inline style wins the
+  // cascade, so theme the dialog surface here for dark mode support.
+  const dialogStyle: React.CSSProperties = {
+    borderRadius: "4px",
+    background: theme.palette.background.paper,
+    color: theme.palette.text.primary,
+  };
 
   const handleLogin = (formData: UserCredentialsFormDataType) => {
     console.log("login", formData);
@@ -175,7 +185,7 @@ export const Login = ({ login, register }: LoginPropsInterface) => {
       </div>
       {openModal === "login" && (
         <Dialog
-          style={{ borderRadius: "4px" }}
+          style={dialogStyle}
           aria-label="login form"
           isOpen={openModal === "login"}
         >
@@ -191,7 +201,7 @@ export const Login = ({ login, register }: LoginPropsInterface) => {
       )}
       {openModal === "register" && (
         <Dialog
-          style={{ borderRadius: "4px" }}
+          style={dialogStyle}
           aria-label="register form"
           isOpen={openModal === "register"}
         >

--- a/ui/src/providers/app-provider.tsx
+++ b/ui/src/providers/app-provider.tsx
@@ -6,22 +6,59 @@ import { AuthProvider } from "../contexts/auth";
 import "react-toastify/dist/ReactToastify.min.css";
 import { ToastContainer } from "react-toastify";
 
-import { ThemeProvider, createTheme } from "@mui/material/styles";
-import Theme from "styles/theme";
-const theme = createTheme(Theme);
+import { ThemeProvider } from "@mui/material/styles";
+import { PaletteMode } from "@mui/material";
+import CssBaseline from "@mui/material/CssBaseline";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { getTheme } from "styles/theme";
+
+const COLOR_MODE_STORAGE_KEY = "todos-color-mode";
+
+export const ColorModeContext = React.createContext<{
+  mode: PaletteMode;
+  toggleColorMode: () => void;
+}>({ mode: "light", toggleColorMode: () => {} });
+
+export const useColorMode = () => React.useContext(ColorModeContext);
 
 type AppProviderProps = {
   children: React.ReactNode;
 };
 
 export const AppProvider = ({ children }: AppProviderProps) => {
+  const prefersDark = useMediaQuery("(prefers-color-scheme: dark)");
+  const [mode, setMode] = React.useState<PaletteMode>(() => {
+    const stored = localStorage.getItem(COLOR_MODE_STORAGE_KEY);
+    if (stored === "light" || stored === "dark") return stored;
+    return prefersDark ? "dark" : "light";
+  });
+
+  const colorMode = React.useMemo(
+    () => ({
+      mode,
+      toggleColorMode: () => {
+        setMode((prev) => {
+          const next = prev === "light" ? "dark" : "light";
+          localStorage.setItem(COLOR_MODE_STORAGE_KEY, next);
+          return next;
+        });
+      },
+    }),
+    [mode]
+  );
+
+  const theme = React.useMemo(() => getTheme(mode), [mode]);
+
   return (
     <React.StrictMode>
       <Suspense fallback={<div>Loading... </div>}>
-        <ThemeProvider theme={theme}>
-          <AuthProvider>{children}</AuthProvider>
-        </ThemeProvider>
-        <ToastContainer />
+        <ColorModeContext.Provider value={colorMode}>
+          <ThemeProvider theme={theme}>
+            <CssBaseline enableColorScheme />
+            <AuthProvider>{children}</AuthProvider>
+          </ThemeProvider>
+        </ColorModeContext.Provider>
+        <ToastContainer theme={mode} />
       </Suspense>
     </React.StrictMode>
   );

--- a/ui/src/styles/emotion.d.ts
+++ b/ui/src/styles/emotion.d.ts
@@ -1,0 +1,8 @@
+import "@emotion/react";
+import { Theme as MuiTheme } from "@mui/material/styles";
+
+// MUI's ThemeProvider injects its theme into emotion's context, so emotion
+// styled components receive the full MUI theme (including `colors`).
+declare module "@emotion/react" {
+  export interface Theme extends MuiTheme {}
+}

--- a/ui/src/styles/theme.ts
+++ b/ui/src/styles/theme.ts
@@ -1,9 +1,25 @@
-import { PaletteColorOptions } from "@mui/material";
-import { PaletteOptions } from "@mui/material/styles";
+import { PaletteColorOptions, PaletteMode } from "@mui/material";
+import {
+  createTheme,
+  PaletteOptions,
+  Theme as MuiTheme,
+} from "@mui/material/styles";
 import { IPropsColor } from "interfaces";
 import { TypeText, TypeBackground } from "@mui/material/styles/createPalette";
 
-const colors: IPropsColor = {
+// Expose the semantic color tokens on the MUI theme so emotion styled
+// components can read them from context and react to mode changes.
+declare module "@mui/material/styles" {
+  interface Theme {
+    colors: IPropsColor;
+  }
+  interface ThemeOptions {
+    colors?: IPropsColor;
+  }
+}
+
+// Brand colors — identical in both modes
+const brand = {
   navy: "#013d54",
   navyLight: "#3a6781",
   navyDark: "#00172b",
@@ -19,7 +35,11 @@ const colors: IPropsColor = {
   greyCool: "#E5E6E5",
   greyCloudy: "#c9c9c8",
   greyCharcoal: "#363936",
-  // Semantic tokens for surfaces/text (light theme)
+};
+
+// Semantic tokens for surfaces/text, per mode
+const lightColors: IPropsColor = {
+  ...brand,
   pageBg: "#f4f6f8",
   surface: "#ffffff",
   border: "#d5d8dc",
@@ -28,52 +48,74 @@ const colors: IPropsColor = {
   cardHeader: "#e3f1fb",
 };
 
-const primary: PaletteColorOptions = {
-  main: colors.ocean,
-  contrastText: "#ffffff",
+const darkColors: IPropsColor = {
+  ...brand,
+  pageBg: "#10161a",
+  surface: "#1c242b",
+  border: "#3b464f",
+  textPrimary: "#e6e9eb",
+  textSecondary: "#9fa8ae",
+  cardHeader: "#16324a",
 };
 
-const secondary: PaletteColorOptions = {
-  main: colors.tangerine,
-  contrastText: "#ffffff",
+export const getColors = (mode: PaletteMode): IPropsColor =>
+  mode === "dark" ? darkColors : lightColors;
+
+const getPalette = (mode: PaletteMode): PaletteOptions => {
+  const colors = getColors(mode);
+
+  const primary: PaletteColorOptions = {
+    main: colors.ocean,
+    contrastText: "#ffffff",
+  };
+
+  const secondary: PaletteColorOptions = {
+    main: colors.tangerine,
+    contrastText: "#ffffff",
+  };
+
+  const warning: PaletteColorOptions = {
+    main: colors.tangerineLight,
+    contrastText: colors.greyCharcoal,
+  };
+
+  const success: PaletteColorOptions = {
+    main: colors.grassGreen,
+    contrastText: colors.greyCharcoal,
+  };
+
+  const info: PaletteColorOptions = {
+    main: mode === "dark" ? colors.navyLight : colors.navy,
+    contrastText: "#ffffff",
+  };
+
+  const text: Partial<TypeText> = {
+    primary: colors.textPrimary,
+    secondary: colors.textSecondary,
+  };
+
+  const background: Partial<TypeBackground> = {
+    default: colors.pageBg,
+    paper: colors.surface,
+  };
+
+  return {
+    mode,
+    primary,
+    secondary,
+    warning,
+    success,
+    info,
+    text,
+    background,
+    divider: colors.border,
+  };
 };
 
-const warning: PaletteColorOptions = {
-  main: colors.tangerineLight,
-  contrastText: colors.greyCharcoal,
-};
+export const getTheme = (mode: PaletteMode): MuiTheme =>
+  createTheme({ palette: getPalette(mode), colors: getColors(mode) });
 
-const success: PaletteColorOptions = {
-  main: colors.grassGreen,
-  contrastText: colors.greyCharcoal,
-};
-
-const info: PaletteColorOptions = {
-  main: colors.navy,
-  contrastText: "#ffffff",
-};
-const text: Partial<TypeText> = {
-  primary: colors.textPrimary,
-  secondary: colors.textSecondary,
-};
-
-const background: Partial<TypeBackground> = {
-  default: colors.pageBg,
-  paper: colors.surface,
-};
-
-const palette: PaletteOptions = {
-  mode: "light",
-  primary,
-  secondary,
-  warning,
-  success,
-  info,
-  text,
-  background,
-  divider: colors.border,
-};
-
-const Theme = { colors, palette };
+// Back-compat default export: light-mode tokens/palette
+const Theme = { colors: lightColors, palette: getPalette("light") };
 
 export default Theme;

--- a/ui/src/test/test-utils.tsx
+++ b/ui/src/test/test-utils.tsx
@@ -1,9 +1,9 @@
 import React, { FC, ReactElement } from "react";
 import { render, RenderOptions } from "@testing-library/react";
-import { ThemeProvider, createTheme } from "@mui/material/styles";
-import Theme from "styles/theme";
+import { ThemeProvider } from "@mui/material/styles";
+import { getTheme } from "styles/theme";
 
-const theme = createTheme(Theme);
+const theme = getTheme("light");
 
 const AllTheProviders: FC<{ children: React.ReactNode }> = ({ children }) => {
   return <ThemeProvider theme={theme}>{children}</ThemeProvider>;


### PR DESCRIPTION
## What

Adds full dark mode support to the UI, building on the theme unification from #20:

- **Mode toggle** — moon/sun icon button in the header; choice persists to `localStorage`, first visit follows the OS `prefers-color-scheme`.
- **Mode-aware theme** (`ui/src/styles/theme.ts`) — every semantic token (`pageBg`, `surface`, `border`, `textPrimary`, `textSecondary`, `cardHeader`) now has light and dark variants; `getTheme(mode)` builds the MUI theme and attaches `colors` to it.
- **Context-driven styling** — emotion styled components switched from static `Theme.colors` imports to `${({ theme }) => theme.colors.X}` callbacks (typed via new `emotion.d.ts`), so all borders, surfaces and card headers flip with the mode. Inline MUI Card `style` borders moved to `sx` + `borderColor: "divider"`.
- **Provider wiring** — `ColorModeContext` + `useColorMode()` in `app-provider.tsx`; `CssBaseline` now owns body background/text (hardcoded values removed from `index.css`); toasts follow the mode.
- **Edge cases** — the `@reach/dialog` login/register modal ships a hardcoded white background, themed via inline style (wins the cascade); the drag-highlight green darkens in dark mode so text stays readable.

## Why

Follow-up to the contrast fixes in #20: the app only had a light palette, and the styling was statically bound to it, making dark mode impossible without this refactor.

## Verified

- Toggled both directions in the browser: body flips `#f4f6f8` ↔ `#10161a`, preference survives reload, login modal renders a proper dark surface with visible outlined fields; an open dialog restyles live on toggle.
- `tsc --noEmit` clean.
- Jest: 1 test passes as before; two suites fail on a pre-existing config issue (duplicate jest config + unresolved `constants/navigation` imports) — confirmed identical on a clean tree, unrelated to this change.

## Reviewer notes

- `.claude/launch.json` is dev-tooling config for browser-preview verification; drop it from the PR if unwanted.
- `header-bar/styles.ts` intentionally keeps a static `navyDark` import — it's a brand constant identical in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)